### PR TITLE
🚚 애니메이션 2주차 과제

### DIFF
--- a/AnimeStudyByNayeon/AnimeStudyByNayeon/SceneDelegate.swift
+++ b/AnimeStudyByNayeon/AnimeStudyByNayeon/SceneDelegate.swift
@@ -21,7 +21,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let window = UIWindow(windowScene: windowScene)
 //        window.rootViewController = MovingViewController()
 //        window.rootViewController = ToastMessageViewController()
-        window.rootViewController = ButtonViewController()
+//        window.rootViewController = ButtonViewController()
+        window.rootViewController = SegmentedViewController()
         window.makeKeyAndVisible()
         self.window = window
     }

--- a/AnimeStudyByNayeon/AnimeStudyByNayeon/SegmentedControl/SegmentedViewController.swift
+++ b/AnimeStudyByNayeon/AnimeStudyByNayeon/SegmentedControl/SegmentedViewController.swift
@@ -28,7 +28,7 @@ final class SegmentedViewController: UIViewController {
     private func setLayout() {
         segmentedControl.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide).offset(20)
-            $0.leading.trailing.equalToSuperview().inset(89)
+            $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(44)
         }
     }

--- a/AnimeStudyByNayeon/AnimeStudyByNayeon/SegmentedControl/SegmentedViewController.swift
+++ b/AnimeStudyByNayeon/AnimeStudyByNayeon/SegmentedControl/SegmentedViewController.swift
@@ -1,0 +1,35 @@
+//
+//  SegmentedViewController.swift
+//  AnimeStudyByNayeon
+//
+//  Created by 김나연 on 5/27/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class SegmentedViewController: UIViewController {
+    
+    let segmentedControl = UnderlineSegmentedControl(items: ["One", "Two", "Three"])
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        view.backgroundColor = .white
+        
+        view.addSubview(segmentedControl)
+        segmentedControl.snapshotView(afterScreenUpdates: false)
+        
+        setLayout()
+    }
+    
+    private func setLayout() {
+        segmentedControl.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(20)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(44)
+        }
+    }
+}

--- a/AnimeStudyByNayeon/AnimeStudyByNayeon/SegmentedControl/SegmentedViewController.swift
+++ b/AnimeStudyByNayeon/AnimeStudyByNayeon/SegmentedControl/SegmentedViewController.swift
@@ -28,7 +28,7 @@ final class SegmentedViewController: UIViewController {
     private func setLayout() {
         segmentedControl.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide).offset(20)
-            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.leading.trailing.equalToSuperview().inset(89)
             $0.height.equalTo(44)
         }
     }

--- a/AnimeStudyByNayeon/AnimeStudyByNayeon/SegmentedControl/UnderlineSegmentedControl.swift
+++ b/AnimeStudyByNayeon/AnimeStudyByNayeon/SegmentedControl/UnderlineSegmentedControl.swift
@@ -1,0 +1,69 @@
+//
+//  UnderlineSegmentedControl.swift
+//  AnimeStudyByNayeon
+//
+//  Created by 김나연 on 5/27/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class UnderlineSegmentedControl: UISegmentedControl {
+    
+    // MARK: - Property
+    private let underlineView = UIView().then {
+        $0.backgroundColor = .systemBlue
+    }
+    private var underlineLeadingConstraint: Constraint?
+    
+    // MARK: - Life Cycle
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.removeBackgroundAndDivider()
+    }
+    
+    override init(items: [Any]?) {
+        super.init(items: items)
+        self.removeBackgroundAndDivider()
+        setLayout()
+        addTarget()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setLayout() {
+        addSubview(underlineView)
+        layoutIfNeeded()
+        let segmentWidth = bounds.width / CGFloat(numberOfSegments)
+        underlineView.snp.makeConstraints {
+            $0.bottom.equalToSuperview()
+            $0.height.equalTo(2)
+            $0.width.equalTo(segmentWidth)
+            underlineLeadingConstraint = $0.leading.equalTo(segmentWidth * CGFloat(selectedSegmentIndex)).constraint
+        }
+    }
+    
+    private func addTarget() {
+        addTarget(self, action: #selector(segmentChanged), for: .valueChanged)
+    }
+    
+    private func removeBackgroundAndDivider() {
+        let image = UIImage()
+        self.setBackgroundImage(image, for: .normal, barMetrics: .default)
+        self.setBackgroundImage(image, for: .selected, barMetrics: .default)
+        self.setBackgroundImage(image, for: .highlighted, barMetrics: .default)
+        self.setDividerImage(image, forLeftSegmentState: .normal, rightSegmentState: .normal, barMetrics: .default)
+    }
+    
+    @objc private func segmentChanged() {
+        let segmentWidth = bounds.width / CGFloat(numberOfSegments)
+        underlineLeadingConstraint?.update(inset: segmentWidth * CGFloat(selectedSegmentIndex))
+        UIView.animate(withDuration: 0.2) {
+            self.layoutIfNeeded()
+        }
+    }
+}

--- a/AnimeStudyByNayeon/AnimeStudyByNayeon/SegmentedControl/UnderlineSegmentedControl.swift
+++ b/AnimeStudyByNayeon/AnimeStudyByNayeon/SegmentedControl/UnderlineSegmentedControl.swift
@@ -43,7 +43,7 @@ final class UnderlineSegmentedControl: UISegmentedControl {
             $0.bottom.equalToSuperview()
             $0.height.equalTo(2)
             $0.width.equalTo(segmentWidth)
-            underlineLeadingConstraint = $0.leading.equalTo(segmentWidth * CGFloat(selectedSegmentIndex)).constraint
+            underlineLeadingConstraint = $0.leading.equalToSuperview().offset(segmentWidth * CGFloat(selectedSegmentIndex)).constraint
         }
     }
     
@@ -61,7 +61,7 @@ final class UnderlineSegmentedControl: UISegmentedControl {
     
     @objc private func segmentChanged() {
         let segmentWidth = bounds.width / CGFloat(numberOfSegments)
-        underlineLeadingConstraint?.update(inset: segmentWidth * CGFloat(selectedSegmentIndex))
+        underlineLeadingConstraint?.update(offset: segmentWidth * CGFloat(selectedSegmentIndex))
         UIView.animate(withDuration: 0.2) {
             self.layoutIfNeeded()
         }

--- a/AnimeStudyByNayeon/AnimeStudyByNayeon/SegmentedControl/UnderlineSegmentedControl.swift
+++ b/AnimeStudyByNayeon/AnimeStudyByNayeon/SegmentedControl/UnderlineSegmentedControl.swift
@@ -27,7 +27,6 @@ final class UnderlineSegmentedControl: UISegmentedControl {
     override init(items: [Any]?) {
         super.init(items: items)
         self.removeBackgroundAndDivider()
-        setLayout()
         addTarget()
     }
     
@@ -35,10 +34,15 @@ final class UnderlineSegmentedControl: UISegmentedControl {
         fatalError("init(coder:) has not been implemented")
     }
     
-    private func setLayout() {
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        guard underlineLeadingConstraint == nil else { return }
+        
         addSubview(underlineView)
-        layoutIfNeeded()
+        
         let segmentWidth = bounds.width / CGFloat(numberOfSegments)
+        
         underlineView.snp.makeConstraints {
             $0.bottom.equalToSuperview()
             $0.height.equalTo(2)


### PR DESCRIPTION
## ✅ 작업(과제) 내용

- [x] Segmented Control 구현

##  💡 새로 알게 된 내용

### Segmented Control

- `UISegmentedControl`을 커스텀할 때 배경색과 divider를 제거하는 과정이 필요
```
override init(frame: CGRect) {
    super.init(frame: frame)
    self.removeBackgroundAndDivider()
  }
  override init(items: [Any]?) {
    super.init(items: items)
    self.removeBackgroundAndDivider()
  }
  required init?(coder: NSCoder) {
    fatalError()
  }
  
  private func removeBackgroundAndDivider() {
    let image = UIImage()
    self.setBackgroundImage(image, for: .normal, barMetrics: .default)
    self.setBackgroundImage(image, for: .selected, barMetrics: .default)
    self.setBackgroundImage(image, for: .highlighted, barMetrics: .default)
    self.setDividerImage(image, forLeftSegmentState: .selected, rightSegmentState: .normal, barMetrics: .default)
  }
```
- `underlineLeadingConstraint`로 밑줄의 시작 위치를 제어
- `layoutIfNeeded()`: 뷰의 레이아웃을 강제로 지금 즉시 계산하고 적용하도록 함, UIKit은 일반적으로 레이아웃 업데이트를 비동기적으로 처리하는데, 지금 당장 정확한 값을 알아야하므로 레이아웃을 즉시 적용시킬 때 필요한 함수

할애할 시간이 너무 부족해서 세그먼트 바로 밑으로 가운데 정렬 되도록 구현하고 싶었는데
잘 안돼서 뷰컨에서 대충 정렬만 맞춰주었습니다..

---
### ✌️🤓 오류 해결했다
`let segmentWidth = bounds.width / CGFloat(numberOfSegments)` 얘를 호출할 때 `bounds.width == 0`이라 생긴 오류였습니다
해결방법: `layoutSubviews()`를 오버라이드 해주었더니 제약 설정이 잘 되었습니다. layoutSubviews()는 UIKit이 Auto Layout을 계산하고 뷰 크기를 결정한 직후에 호출되기 때문에 해결된다는 것인데, 라이프사이클에 대해 더 공부해야겠다는 생각이 들었습니다.

 ### UIKit 레이아웃 사이클
`linit() / loadView() → addSubview() → setNeedsLayout() → layoutSubviews()`

## 📸 스크린샷

<!-- 작업한 화면의 스크린샷 -->
| 처음 | 수정후 |
|----------|------------|
| ![첫](https://github.com/user-attachments/assets/66170395-a55b-4ef7-bb63-05fe2c5fe0b2) | ![후](https://github.com/user-attachments/assets/be430cd4-d359-46f8-8001-3d619c7f3f3d) |
| 처음의 그지 UI | 나중 |